### PR TITLE
Transformation operations

### DIFF
--- a/glow/geometry_layouts/geometries.py
+++ b/glow/geometry_layouts/geometries.py
@@ -117,19 +117,35 @@ class GenericSurface(ABC):
         # Build the Z-axis of rotation positioned in the figure center
         z_axis = make_vector_from_points(
             self.o, make_vertex((center[0], center[1], 1)))
+        # Rotate the surface elements
+        self.rotate_from_axis(angle, z_axis)
+
+    def rotate_from_axis(self, angle: float, axis: Any) -> None:
+        """
+        Method that rotates the surface geometry. The face, its border
+        edges, vertices and construction circle are rotated by the given
+        angle expressed in degrees around the given axis.
+
+        Parameters
+        ----------
+        angle : float
+                The rotation angle in degrees
+        axis  : Any
+                The axis object around which the rotation takes place
+        """
         # Convert the rotation angle in radians
         self.rotation = math.radians(angle)
         # Rotate the GEOM face of the surface, if any has been built
         if self.face:
-            self.face = make_rotation(self.face, z_axis, self.rotation)
+            self.face = make_rotation(self.face, axis, self.rotation)
         for i in range(len(self.vertices)):
             self.vertices[i] = make_rotation(
-                self.vertices[i], z_axis, self.rotation)
+                self.vertices[i], axis, self.rotation)
         # Re-build the borders
         self.borders = self._build_borders()
         # Rotate the construction circle
         self.out_circle = make_rotation(
-            self.out_circle, z_axis, self.rotation)
+            self.out_circle, axis, self.rotation)
 
     def translate(self, new_pos: Tuple[float, float, float]) -> None:
         """

--- a/glow/geometry_layouts/lattices.py
+++ b/glow/geometry_layouts/lattices.py
@@ -1759,26 +1759,29 @@ class Lattice():
             # FIXME put into log
             print("No rotation is performed as the given angle is 0.0°")
             return
+        # Convert the rotation angle in radians
+        rotation = math.radians(angle)
 
         # Build the Z-axis of rotation
         z_axis = make_vector((0, 0, 1))
-        # Rotate the lattice compound
-        self.lattice_cmpd = make_rotation(
-            self.lattice_cmpd, z_axis, math.radians(angle))
+        # Rotate the lattice compounds
+        self.lattice_cmpd = make_rotation(self.lattice_cmpd, z_axis, rotation)
+        self.lattice_tech = make_rotation(self.lattice_tech, z_axis, rotation)
+        self.lattice_org = make_rotation(self.lattice_org, z_axis, rotation)
         # Re-build the lattice edges from the compound
         self.lattice_edges = make_partition(
             [self.lattice_cmpd], [], ShapeType.EDGE)
         # Rotate each cell of the lattice
         for cell in self.lattice_cells:
-            cell.rotate(angle)
+            cell.rotate_from_axis(angle, z_axis)
         # Rotate the lattice box, if any
         if self.lattice_box:
-            self.lattice_box.rotate(angle)
+            self.lattice_box.rotate_from_axis(angle, z_axis)
         # Rotate the lattice compound on which a symmetry operation has been
         # applied, if any
         if self.symmetry_type != SymmetryType.FULL:
             self.lattice_symm = make_rotation(
-                self.lattice_symm, z_axis, math.radians(angle))
+                self.lattice_symm, z_axis, rotation)
 
         # FIXME re-evaluate lattice characteristic dimensions??
 


### PR DESCRIPTION
Problems have been found when applying transformation operations, i.e. translation and rotation, to the lattice (as an instance of the `Lattice` class).
In particular, it resulted that:
- the box was not translated properly;
- the regions of the cells in the lattice were not rotated accordingly with the lattice rotation;
- some lattice compound objects were not rotated at all when rotating the whole lattice.

These problems prevented the regions of the lattice from being displayed correctly when the lattice itself was translated or rotated.

Changes have been performed to address the above-mentioned problems.