### PR TITLE
Added association of SALOME shapes to GEOM type of shapes for surfaces and edges

### DIFF
--- a/glow/interface/geom_interface.py
+++ b/glow/interface/geom_interface.py
@@ -50,8 +50,6 @@ class ShapeType(Enum):
     VERTEX    : int = geompy.ShapeType['VERTEX']
     SHAPE     : int = geompy.ShapeType['SHAPE']
     FLAT      : int = geompy.ShapeType['FLAT']
-    PLANAR    : int = 10
-    POLYGON   : int = 11
 
 
 # Dictionary associating the name of the GEOM type of shape VS the
@@ -67,8 +65,12 @@ NAME_VS_SHAPE_TYPE: Dict[str, ShapeType] = {
     'VERTEX': ShapeType.VERTEX,
     'SHAPE': ShapeType.SHAPE,
     'FLAT': ShapeType.FLAT,
-    'PLANAR': ShapeType.PLANAR,
-    'POLYGON': ShapeType.POLYGON
+    'DISK': ShapeType.FACE,
+    'PLANAR': ShapeType.FACE,
+    'POLYGON': ShapeType.FACE,
+    'ARC_CIRCLE': ShapeType.EDGE,
+    'CIRCLE': ShapeType.EDGE,
+    'SEGMENT': ShapeType.EDGE
 }
 
 


### PR DESCRIPTION
Shapes identified by SALOME with a specific name are now associated to their corresponding topological type of shape. In particular, shapes representing a surface are now associated to the `ShapeType.FACE` member, whereas those representing an edge (either linear or curvilinear) are now associated to the `ShapeType.EDGE` member.