### PR TITLE
Handling restore geometry layout of cells

### DIFF
--- a/glow/geometry_layouts/cells.py
+++ b/glow/geometry_layouts/cells.py
@@ -413,8 +413,7 @@ class Cell(ABC):
         centered_regions = []
         # List containing the cell 'Circle' objects, filtered so that
         # only the cell-centered ones are considered
-        centered_circles = [c for c in self.inner_circles if
-                              get_min_distance(c.o, self.figure.o) < 1e-5]
+        centered_circles = self.get_centered_circles()
         # Loop through all the regions of the cell technological geometry
         for region in self.tech_geom_props:
             # Continue with the next region if it is not cell-centered
@@ -1537,6 +1536,14 @@ class Cell(ABC):
         if edges_to_add:
             self.face = make_partition(
                 [self.face], edges_to_add, ShapeType.FACE)
+
+    def get_centered_circles(self) -> List[Circle]:
+        """
+        Method that returns a list of the cell-centered `Circle` objects of
+        the cell.
+        """
+        return [circle for circle in self.inner_circles \
+                if get_min_distance(circle.o, self.figure.o) < 1e-5]
 
 
 class RectCell(Cell):


### PR DESCRIPTION
Previously, once a cell has been declared, it was not possible to restore its geometry layout by removing all its inner circles. This functionality was required to address cases where the circular regions of a cell, representing the pin's regions, were cut by an overlapping layer of cells. In this situation, users might want to restore the geometry layout of the cells and set its properties.
A dedicated method `restore` has been included in the `Cell` class to restore its geometry layout to a state without any circular region; it also re-initializes the dictionaries of the cell's properties and sectorization options. 
Another method `restore_cells` has also been implemented in the `Lattice` class to restore the geometry layout of a given list of cells of the lattice and set their properties all together according to the provided dictionary of property type VS value.