### PR TITLE
Handling regions extraction

### DIFF
--- a/glow/generator/geom_extractor.py
+++ b/glow/generator/geom_extractor.py
@@ -835,7 +835,6 @@ class LatticeDataExtractor():
             # COMPOUND-type case
             edges_in_place = extract_sub_shapes(edge, ShapeType.EDGE)
             if edges_in_place:
-                print("!!!! EDGES COMPOUND !!!")
                 return [
                     self.id_vs_edge[build_edge_id(e)] for e in edges_in_place]
             else:


### PR DESCRIPTION
Previously, when extracting the geometric information for exporting the surface geometry in the TDT file (after calling the function `analyse_and_generate_tdt`), the analysis could be performed using regions of the lattice that were not up to date according to the last operation performed before running the TDT export. This was especially true when the `analyse_and_generate_tdt` function was called without displaying the built lattice in the SALOME viewer (`Lattice.show` method). 

To address this issue, the `build_regions` method of the `Lattice` instance is now called when initializing a `LatticeDataExtractor` instance if one of the following conditions is met: if the regions need to be updated (by checking a flag of the `Lattice` instance) or if the geometry type of the cells to be processed is different from the one used to display the lattice regions. This ensures that the lattice compound object, from which the edges are extracted, is updated correctly according to the indicated geometry type of the cells in the lattice; the same goes for the `Region` objects.

In addition, to ensure that the correct regions are extracted according to the `GeometryType` passed to the function `analyse_and_generate_tdt`, modifications have been performed to the private methods dealing with updating the lattice compound object and the lattice box.