### PR TITLE
Added lattice translation during analysis

### DIFF
--- a/glow/geometry_layouts/lattices.py
+++ b/glow/geometry_layouts/lattices.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Set, Tuple, Union
 from glow.geometry_layouts.cells import Cell, HexCell, RectCell, Region
 from glow.geometry_layouts.geometries import GenericSurface, Hexagon, \
     Rectangle, build_hexagon
-from glow.geometry_layouts.utility import build_compound_borders, \
+from glow.geometry_layouts.utility import build_compound_borders, translate_wrt_reference, \
     update_relative_pos
 from glow.interface.geom_interface import ShapeType, add_to_study, \
     add_to_study_in_father, clear_view, display_shape, \
@@ -1254,11 +1254,8 @@ class Lattice():
         if self.symmetry_type != SymmetryType.FULL:
             # Update the compound position relative to the shifted lattice
             # center and apply translation
-            face_to_center = update_relative_pos(
-                make_cdg(self.lattice_symm), pre_center, new_pos)
-            self.lattice_symm = make_translation(
-                self.lattice_symm, make_vector_from_points(
-                    make_cdg(self.lattice_symm), make_vertex(face_to_center)))
+            self.lattice_symm = translate_wrt_reference(
+                self.lattice_symm, pre_center, new_pos)
 
         # Set the need to update the lattice geometry
         self.is_update_needed = True

--- a/glow/geometry_layouts/utility.py
+++ b/glow/geometry_layouts/utility.py
@@ -7,7 +7,7 @@ from typing import Any, List, Tuple
 
 from glow.interface.geom_interface import ShapeType, \
   extract_sorted_sub_shapes, fuse_edges_in_wire, get_closed_free_boundary, \
-  get_inertia_matrix, get_point_coordinates, make_face, make_fuse
+  get_inertia_matrix, get_point_coordinates, make_cdg, make_face, make_fuse, make_translation, make_vector_from_points, make_vertex
 
 
 def build_compound_borders(cmpd: Any) -> List[Any]:
@@ -142,3 +142,36 @@ def get_principal_axis_angle(shape: Any) -> float:
     py = inertia_matrix[-2]
     # Return the rotation angle in degrees
     return math.degrees(math.atan2(py, px))
+
+
+def translate_wrt_reference(
+        shape: Any,
+        old_ref_point: Any,
+        new_ref_coords: Tuple[float, float, float]) -> Any:
+    """
+    Function that translates a geometric shape so that it keeps its relative
+    distance from a reference point, whose previous position is provided as
+    a vertex object, while its new position by means of its XYZ coordinates.
+
+    Parameters
+    ----------
+    shape : Any
+        The geometric shape to be translated
+    old_ref_point : Any
+        A vertex object identifying the previous reference point of the shape
+    new_ref_coords : Tuple[float, float, float]
+        The coordinates of the reference point for the shape after its
+        translation
+
+    Returns
+    -------
+    The given shape translated so that it keeps its relative distance from
+    the new reference point.
+    """
+    # Build a vertex identifying the shape CDG
+    cdg = make_cdg(shape)
+    # Get the shape's CDG coordinates so that the relative distance from
+    # the new reference point is kept the same
+    shape_to_center = update_relative_pos(cdg, old_ref_point, new_ref_coords)
+    return make_translation(
+        shape, make_vector_from_points(cdg, make_vertex(shape_to_center)))


### PR DESCRIPTION
Previously, it happened that the SALT module of DRAGON failed in tracking a lattice if a specific combination of type of cells and type of symmetry was present, and the lower-left corner of the geometry did not coincide with the origin of the XYZ space. In particular:

- for lattice with cartesian cells, if the `FULL` or `HALF` symmetry types were applied;
- for lattice with hexagonal cells, if the `THIRD` and `SIXTH` symmetry types were applied.

To make the tracking work, the user would have needed to translate the lattice properly before exporting the geometry. 

To relieve the user from this operation, now when the function `analyse_and_generate_tdt` is called, the translation of the lattice compound object, the corresponding `Region` objects and the lattice centre are performed automatically for the above-mentioned cases, and only if not already done by the user beforehand. 