### PR TITLE
Added toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ glow/__pycache__/
 .venv/
 tests/outputs
 docs/_build
+build
 
 # Ignore other common Python artifacts
 *.pyc

--- a/README.rst
+++ b/README.rst
@@ -107,13 +107,26 @@ dependencies must be satisfied:
 How to Install
 --------------
 
-To install the |TOOL| application, please check that all the dependencies
-are met, and then clone the repository at
+To install the |TOOL| application, clone the repository at
 https://github.com/newcleo-dev-team/glow using the following command:
 
   .. code-block:: bash
 
     git clone https://github.com/newcleo-dev-team/glow
+
+Now, from the root folder of |TOOL| the following command can be run to
+automatically install all the needed dependencies:
+
+  .. code-block:: bash
+
+      pip install .
+
+To upgrade the |TOOL| package, please type the ``install`` command along with
+the ``--upgrade`` or ``-U`` flag:
+
+  .. code-block:: bash
+
+      pip install --upgrade .
 
 Since |TOOL| exploits the *GEOM* module of *SALOME*, a correct installation
 of *SALOME* is required. Please, refer to the *Building and installing* section
@@ -126,8 +139,16 @@ itself.
 How to Use
 ----------
 
-|TOOL| can be used directly by writing down a Python script that exploits the
-provided classes and methods to:
+|TOOL| can be used directly by writing down a Python script where the single
+needed modules can be imported; alternatively, users can import all the modules
+at once to have them available by setting the following import instruction:
+
+.. code-block:: python
+
+  from glow import *
+
+Given that, classes and methods are directly accessible and users can exploit
+them to:
 
 - assemble the geometry;
 - assign properties to regions;

--- a/docs/source/application_configuration.rst
+++ b/docs/source/application_configuration.rst
@@ -2,13 +2,26 @@
 Application configuration
 =========================
 
-To install the |TOOL| application, please check that all the dependencies
-are met, and then clone the repository at
+To install the |TOOL| application, clone the repository at
 https://github.com/newcleo-dev-team/glow using the following command:
 
   .. code-block:: bash
 
     git clone https://github.com/newcleo-dev-team/glow
+
+Now, from the root folder of |TOOL| the following command can be run to
+automatically install all the needed dependencies:
+
+  .. code-block:: bash
+
+      pip install .
+
+To upgrade the |TOOL| package, please type the ``install`` command along with
+the ``--upgrade`` or ``-U`` flag:
+
+  .. code-block:: bash
+
+      pip install --upgrade .
 
 Since |TOOL| exploits the *GEOM* module of *SALOME*, a correct installation
 of the *SALOME* platform is required.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1360,8 +1360,16 @@ generated. Its structure consists of five sections, that are:
 Usage
 -----
 
-|TOOL| can be used directly by writing down a Python script that exploits the
-provided classes and methods to:
+|TOOL| can be used directly by writing down a Python script where the single
+needed modules can be imported; alternatively, users can import all the modules
+at once to have them available by setting the following import instruction:
+
+.. code-block:: python
+
+  from glow import *
+
+Given that, classes and methods are directly accessible and users can exploit
+them to:
 
 - assemble the geometry;
 - assign properties to regions;

--- a/glow/__init__.py
+++ b/glow/__init__.py
@@ -1,8 +1,15 @@
 """
 GLOW (Geometry Layout Oriented Workflows) is a Python application intended
 for providing the DRAGON5 lattice code with a tool for building non-native
-geometries for the Method of Characteristics (MoC) calculations.
+geometries for performing tracking analyses with the SALT module.
 """
+from glow.interface.geom_interface import *
+from glow.geometry_layouts.geometries import *
+from glow.geometry_layouts.cells import *
+from glow.geometry_layouts.lattices import *
+from glow.main import *
+from glow.support.types import *
+from glow.support.utility import *
 
 __version__ = "1.0.0"
 __author__ = "Davide Manzione, Daniele Tomatis"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "GLOW"
+version = "1.0.0"
+description = "Geometry Layout Oriented Workflow"
+authors = [
+    { name = "Davide Manzione", email = "davide.manzione@newcleo.com" },
+    { name = "Daniele Tomatis", email = "daniele.tomatis@newcleo.com" },
+]
+license = {file = "LICENSE"}
+readme = "README.rst"
+keywords = [
+    "unstructured geometry",
+    "surface geometry",
+    "tracking",
+    "DRAGON5",
+    "SALT",
+    "lattice",
+    "assembly"
+]
+classifiers = [
+    "Programming Language :: Python",
+    "Natural Language :: English"
+]
+requires-python = ">=3.11"
+dependencies = [
+    "typing-extensions >= 4.12.2",
+    "PyQt5 >= 5.15.11",
+    "psutil >= 7.0.0",
+    "sphinx >= 8.2.3",
+    "sphinx-rtd-theme >= 3.0.2",
+    "sphinxcontrib-bibtex >= 2.6.3",
+    "myst-parser >= 4.0.1"
+]
+
+[tool.setuptools.packages]
+find = {namespaces = false}
+
+[tool.setuptools.dynamic]
+version = {attr = "glow.__version__"}

--- a/tests/functional/run_test.py
+++ b/tests/functional/run_test.py
@@ -1,10 +1,23 @@
-import subprocess
-from pathlib import Path
 import hashlib
 import os
+import subprocess
 
-# Function to compute the SHA256 hash of a file
-def compute_hash(file_path):
+from pathlib import Path
+
+def compute_hash(file_path: Path) -> str:
+    """
+    Function to compute the SHA256 hash of a file.
+
+    Parameters
+    ----------
+    file_path : Path
+        The ``Path`` object of the file to process.
+
+    Returns
+    -------
+    str
+        The SHA256 hash of a given file.
+    """
     sha256 = hashlib.sha256()
     with open(file_path, "rb") as f:
         for block in iter(lambda: f.read(4096), b""):
@@ -86,5 +99,3 @@ print(f"Passed:              {passed}")
 print(f"Failed:              {failed}")
 print(f"Skipped (no ref):    {skipped}")
 print("────────────────────────────\n")
-    
-

--- a/tests/functional/test_cartesian_assembly.py
+++ b/tests/functional/test_cartesian_assembly.py
@@ -3,15 +3,8 @@ Testing the construction of a lattice made by cartesian cells. The 'MATERIAL'
 property is assigned to each region of the cell technological geometry.
 A lattice is built by including 9 of the built cells.
 """
-
 import os
 import sys
-
-file_path = os.path.abspath(__file__)
-glow_path = os.path.abspath(os.path.join(file_path, "..", "..", ".."))  
-
-if glow_path not in sys.path:
-    sys.path.insert(0, glow_path)
 
 from glow.geometry_layouts.cells import RectCell
 from glow.support.types import *

--- a/tests/functional/test_cartesian_assembly_eighth.py
+++ b/tests/functional/test_cartesian_assembly_eighth.py
@@ -1,18 +1,11 @@
 """
 Testing the construction of a lattice made by cartesian cells. The 'MATERIAL'
 property is assigned to each region of the cell technological geometry.
-A lattice is built by including 36 of the built cells. Symmetry is exploited, 
+A lattice is built by including 36 of the built cells. Symmetry is exploited,
 one-eighth of the complete cartesian lattice is considered.
 """
-
 import os
 import sys
-
-file_path = os.path.abspath(__file__)
-glow_path = os.path.abspath(os.path.join(file_path, "..", "..", ".."))  
-
-if glow_path not in sys.path:
-    sys.path.insert(0, glow_path)
 
 from glow.geometry_layouts.cells import RectCell
 from glow.support.types import *

--- a/tests/functional/test_cartesian_cell.py
+++ b/tests/functional/test_cartesian_cell.py
@@ -2,15 +2,8 @@
 Testing the construction of a cartesian cell. The 'MATERIAL' property is
 assigned to each region of the cell technological geometry.
 """
-
 import os
 import sys
-
-file_path = os.path.abspath(__file__)
-glow_path = os.path.abspath(os.path.join(file_path, "..", "..", "..")) 
-
-if glow_path not in sys.path:
-    sys.path.insert(0, glow_path)
 
 from glow.geometry_layouts.cells import RectCell
 from glow.geometry_layouts.lattices import Lattice
@@ -35,10 +28,9 @@ rect_cell.set_properties(
 # Show the sectorized cell with regions colored according to the 'MATERIAL'
 # property
 rect_cell.show(PropertyType.MATERIAL)
-# Build a lattice made of a central cell 
+# Build a lattice made of a central cell
 lattice = Lattice([rect_cell], 'Cartesian Lattice')
 
 # Perform the lattice faces and edges analysis and generate the output
 # TDT file
 analyse_and_generate_tdt(lattice, os.path.join(os.path.dirname(sys.argv[0]),'test_cartesian_cell'))
-

--- a/tests/functional/test_hex_assembly.py
+++ b/tests/functional/test_hex_assembly.py
@@ -1,20 +1,9 @@
 """
-Modelling of a Hexagonal Assembly made of a central pin fuel 
+Modelling of a Hexagonal Assembly made of a central pin fuel
 cell sorrounded by 6 rings of pin fuel cells. The hexagon is complete.
 """
-
 import os
 import sys
-
-try:
-    file_path = os.path.abspath(__file__)
-    glow_path = os.path.abspath(os.path.join(file_path, "..", "..", ".."))
-
-    if glow_path not in sys.path:
-       sys.path.insert(0, glow_path)
-
-except NameError:
-    pass
 
 from glow.geometry_layouts.cells import *
 from glow.geometry_layouts.lattices import *
@@ -23,10 +12,10 @@ from glow.generator.generator import *
 
 # Declare the values of the hexagonal cells geometrical characteristics
 edge_length = 0.7852193995
-radii_f=[0.1, 0.45, 0.465, 0.525] 
+radii_f = [0.1, 0.45, 0.465, 0.525]
 
 #Build two types of hexagonal cells
-fuel_cell= HexCell(edge_length=edge_length,
+fuel_cell = HexCell(edge_length=edge_length,
                     name="Fuel Cell")
 # Rotate the cells
 fuel_cell.rotate(90)
@@ -61,7 +50,3 @@ lattice.type_geo = LatticeGeometryType.HEXAGON_TRAN
 # Perform the lattice faces and edges analysis and generate the output
 # TDT file
 analyse_and_generate_tdt(lattice, os.path.join(os.path.dirname(sys.argv[0]),'test_hex_assembly'))
-
-
-
-

--- a/tests/functional/test_hex_assembly_sixth.py
+++ b/tests/functional/test_hex_assembly_sixth.py
@@ -1,21 +1,10 @@
 """
-Hexagonal Assembly made of a central pin fuel cell sorrounded by 
-6 rings of pin fuel cells. Symmetry is exploited, one-sixth of 
+Hexagonal Assembly made of a central pin fuel cell sorrounded by
+6 rings of pin fuel cells. Symmetry is exploited, one-sixth of
 the complete hexagon is considered.
 """
-
 import os
 import sys
-
-try:
-    file_path = os.path.abspath(__file__)
-    glow_path = os.path.abspath(os.path.join(file_path, "..", "..", ".."))
-
-    if glow_path not in sys.path:
-       sys.path.insert(0, glow_path)
-
-except NameError:
-    pass
 
 from glow.geometry_layouts.cells import *
 from glow.geometry_layouts.lattices import *
@@ -65,7 +54,3 @@ lattice.apply_symmetry(SymmetryType.SIXTH)
 # Perform the lattice faces and edges analysis and generate the output
 # TDT file
 analyse_and_generate_tdt(lattice, os.path.join(os.path.dirname(sys.argv[0]),'test_hex_assembly_sixth'))
-
-
-
-

--- a/tests/functional/test_hex_assembly_twelfth.py
+++ b/tests/functional/test_hex_assembly_twelfth.py
@@ -1,21 +1,10 @@
 """
-Modelling of a Hexagonal Assembly made of a central pin fuel cell sorrounded by 
-6 rings of pin fuel cells. Symmetry is exploited, one-twelfth of the complete 
+Modelling of a Hexagonal Assembly made of a central pin fuel cell sorrounded by
+6 rings of pin fuel cells. Symmetry is exploited, one-twelfth of the complete
 hexagon is considered.
 """
-
 import os
 import sys
-
-try:
-    file_path = os.path.abspath(__file__)
-    glow_path = os.path.abspath(os.path.join(file_path, "..", "..", ".."))
-
-    if glow_path not in sys.path:
-       sys.path.insert(0, glow_path)
-
-except NameError:
-    pass
 
 from glow.geometry_layouts.cells import *
 from glow.geometry_layouts.lattices import *

--- a/tests/functional/test_hex_cell.py
+++ b/tests/functional/test_hex_cell.py
@@ -5,12 +5,6 @@ assigned to each region of the cell technological geometry.
 import os
 import sys
 
-file_path = os.path.abspath(__file__)
-glow_path = os.path.abspath(os.path.join(file_path, "..", "..", ".."))  
-
-if glow_path not in sys.path:
-    sys.path.insert(0, glow_path)
-
 from glow.geometry_layouts.cells import HexCell
 from glow.geometry_layouts.lattices import Lattice
 from glow.support.types import PropertyType
@@ -37,10 +31,9 @@ hex_cell.set_properties(
 # Update the viewer showing a color for the MATERIAL property type
 hex_cell.show(PropertyType.MATERIAL)
 
-# Build a lattice made of a central cell 
+# Build a lattice made of a central cell
 lattice = Lattice([hex_cell], 'Hexagonal Lattice')
 
 # Perform the lattice faces and edges analysis and generate the output
 # TDT file
 analyse_and_generate_tdt(lattice, os.path.join(os.path.dirname(sys.argv[0]),'test_hex_cell'))
-


### PR DESCRIPTION
A toml file has been added to the project. Now, GLOW can be installed with _pip_ and its modules are visible since they are imported directly when importing GLOW in a Python script. The documentation and the README have been updated to reflect the new state of the project; they explain how to install and import modules. The functional tests have been updated by removing the need to add the modules of GLOW to the PYTHONPATH. The `.gitignore` file has been updated to ignore the `build` folder.