### PR TITLE
Removed unnecessary '.env' file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PYTHONPATH="/opt/SALOME-9.12.0-native-DB12-SRC/BINARIES-DB12/KERNEL/lib/python3.11/site-packages/salome/:/opt/SALOME-9.12.0-native-DB12-SRC/BINARIES-DB12/GEOM/lib/python3.11/site-packages/salome/salome/:/opt/SALOME-9.12.0-native-DB12-SRC/BINARIES-DB12/GEOM/lib/python3.11/site-packages/salome/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "GLOW"
 version = "1.0.0"
-description = "Geometry Layout Oriented Workflow"
+description = "Geometry Layout Oriented Workflows"
 authors = [
     { name = "Davide Manzione", email = "davide.manzione@newcleo.com" },
     { name = "Daniele Tomatis", email = "daniele.tomatis@newcleo.com" },


### PR DESCRIPTION
Since the application can now be installed with _pip_, the file `.env`, which sets the _PYTHONPATH_, has been removed from the repository, as no more necessary.