### PR TITLE
Added GitHub workflow to deploy documentation on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,28 @@
+name: Sphinx build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build HTML
+      working-directory: ./docs
+      run: pip install Sphinx sphinx-rtd-theme myst-parser sphinxcontrib-bibtex && make html
+    - name: Upload artifacts
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: docs/_build/html/
+    - name: Deploy
+      uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,28 +1,33 @@
-name: Sphinx build
+name: Build and deploy documentation to GitHub Pages
 
 on:
+  # Runs on pushes targeting the default branch
   push:
-    branches:
-      - master
+    branches: ["master"]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      contents: read
+      pages: write
+      id-token: write
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Build HTML
-      working-directory: ./docs
-      run: pip install Sphinx sphinx-rtd-theme myst-parser sphinxcontrib-bibtex && make html
-    - name: Upload artifacts
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: docs/_build/html/
-    - name: Deploy
-      uses: actions/deploy-pages@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build HTML
+        working-directory: ./docs
+        run: pip install Sphinx sphinx-rtd-theme myst-parser sphinxcontrib-bibtex && make html
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html/
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,9 @@ executing the following command in the folder ``docs``:
 To see the available templates for generating the documentation in *PDF*
 format and to choose among them, please look at the ``docs/conf.py`` file.
 
+The *html* documentation is available on GitHub Pages at
+https://newcleo-dev-team.github.io/glow/.
+
 .. _How to Contribute:
 
 How to Contribute


### PR DESCRIPTION
To ensure the documentation of GLOW is publicly available on GitHub Pages, a dedicated GitHub workflow has been added to the repository. This workflow has been configured to build the documentation on every push to the master branch and deploy the HTML documentation on GitHub Pages.