### PR TITLE
Changed default LaTeX theme for the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ national_sec = {"country": "4", "sec_level": "1", }
 itns = "1"
 distribution_list = "C\&M all, Luciano Cinotti, ECD/Massimo Ciambrella"
 bibtex_bibfiles = [os.path.join(SOURCE_DIR_NAME, 'glow.bib')]
-latex_theme_to_use = "nwcldocs"
+latex_theme_to_use = "manual"
 
 
 # -- Global substitutions ----------------------------------------------------


### PR DESCRIPTION
The default LaTeX theme to use has been changed from 'nwcldocs' to 'manual' since the previously set value triggers a check on the presence of a LaTeX environment even when building the HTML documentation. This caused a failure when building and deploying the documentation on GitHub Pages.