### PR TITLE
Added support for the multicell surfacic approximation of DRAGON

### DIFF
--- a/glow/generator/generator.py
+++ b/glow/generator/generator.py
@@ -191,13 +191,17 @@ def _write_header(file: TextIOWrapper, tdt_data: TdtData) -> None:
     typegeom   = tdt_data.type_geo.value
     # Get the number of folds of the lattice
     nb_folds   = tdt_data.nb_folds
+    # Get the number of macro regions, if any
+    nb_macros = 1
+    if PropertyType.MACRO in tdt_data.properties:
+        nb_macros = len(tdt_data.properties[PropertyType.MACRO])
     file.writelines([
          "\n",
          "	dat input file for DRAGON5\n",
          "------------------------------------------------------------\n\n\n",
          "* typge, nbfo, node, elem, macr, nreg,    z, mac2\n",
         f"  {typegeom:5d},{nb_folds:5d}, {nbnodes:5d}, {nbelements:5d}, "
-        f"{1:5d},{nbregions:5d}, {0:5d}, {1:5d}\n",
+        f"{nb_macros:5d},{nbregions:5d}, {0:5d}, {1:5d}\n",
          "* index  kindex\n",
         f"  {tdt_data.impressions[0]:5d}  {tdt_data.impressions[1]:6d}  1\n",
          "*     eps    eps0\n",

--- a/glow/generator/generator.py
+++ b/glow/generator/generator.py
@@ -406,9 +406,10 @@ def _write_properties(file: TextIOWrapper, tdt_data: TdtData) -> None:
     # Check if the MATERIAL property type is included; if not, raise an
     # exception
     if PropertyType.MATERIAL not in tdt_data.properties:
-        raise("Error while writing the material indices of the layout's "
-              "regions. No 'PropertyType.MATERIAL' has been defined for any "
-              "of the layout's regions.")
+        raise RuntimeError(
+            "Error while writing the material indices of the layout's "
+            "regions. No 'PropertyType.MATERIAL' has been defined for any "
+            "of the layout's regions.")
     # Write the names of the materials that are present in the layout on
     # separate lines. Each line starts with a '#' so to be ignored.
     mat_names = tdt_data.properties[PropertyType.MATERIAL]

--- a/glow/geometry_layouts/cells.py
+++ b/glow/geometry_layouts/cells.py
@@ -1148,6 +1148,37 @@ class Cell(ABC):
             # Associate a region with its properties
             self.tech_geom_props[tech_face] = prop_types
 
+    def update_properties(
+            self, properties: Dict[PropertyType, List[str]]) -> None:
+        """
+        Method that allows to updates the values of the given property types
+        for all the regions of the cell.
+
+        Parameters
+        ----------
+        properties : Dict[PropertyType, List[str]]
+            Dictionary collecting the properties for each cell's region;
+            different types, given by the ``PropertyType`` enumeration,
+            can be provided.
+        """
+        # Check if the number of cell regions coincides with the number of
+        # property elements for all the given property types
+        no_regions = len(self.tech_geom_props)
+        for prop_type, values in properties.items():
+            if not no_regions == len(values):
+                raise ValueError(
+                    "There is no correspondence between the number "
+                    f"of cell zones ({no_regions}) and that of the "
+                    f"properties with type '{prop_type.name}' (no. "
+                    f"{len(values)})")
+        # Update the dictionary of cell zones VS properties
+        for i, tech_face in enumerate(self.tech_geom_props):
+            # Collect all properties for a region
+            prop_types = {
+                type: values[i] for type, values in properties.items()}
+            # Associate a region with its properties
+            self.tech_geom_props[tech_face].update(prop_types)
+
     def __build_sector_regions(self) -> None:
         """
         Method for building the ``Region`` objects that corresponds to the
@@ -2139,8 +2170,10 @@ def get_region_info(shape: Any, regions: List[Region]) -> str:
             # Build the info about the region name and its properties
             if not region.properties:
                 return region.name + "\n   No associated properties."
+            properties = ""
             for prop_type, value in region.properties.items():
-                return region.name + f"\n   {prop_type.name}: {value}"
+                properties += f"\n   {prop_type.name}: {value}"
+            return region.name + properties
     else:
         raise RuntimeError("The indicated region could be found among "
                             "the cell's ones.")

--- a/glow/geometry_layouts/geometries.py
+++ b/glow/geometry_layouts/geometries.py
@@ -121,6 +121,7 @@ class Surface(ABC):
         # Convert the rotation angle in radians
         self.rotation = math.radians(angle)
         # Rotate the geometric elements of the surface
+        self.o = make_rotation(self.o, axis, self.rotation)
         self.face = make_rotation(self.face, axis, self.rotation)
         for i, _ in enumerate(self.vertices):
             self.vertices[i] = make_rotation(

--- a/glow/geometry_layouts/lattices.py
+++ b/glow/geometry_layouts/lattices.py
@@ -1205,8 +1205,10 @@ class Lattice():
 
         # Update the compound object storing the applied symmetry
         if self.symmetry_type != SymmetryType.FULL:
-            self.lattice_symm = make_common(self.lattice_cmpd,
-                                            self.lattice_symm)
+            # Extract the shape of the symmetry by extracting its
+            # borders and building a face object
+            shape = make_face(build_compound_borders(self.lattice_symm))
+            self.lattice_symm = make_common(self.lattice_cmpd, shape)
 
     def __assemble_box(self, geo_type: GeometryType) -> None:
         """
@@ -2552,6 +2554,37 @@ class Lattice():
 
         # Set the need to update the lattice geometry
         self.is_update_needed = True
+
+    def assign_macro_to_cells(
+            self, index_0: int = 1, base_name: str = "MAC") -> None:
+        """
+        Method that assignes the names of the property ``PropertyType.MACRO``
+        to the cells the lattice is made of.
+        Given the starting index and the base name of the macros, a loop
+        through all the cells and the lattice's box is performed. All the
+        regions of a cell will share the same name of the macro made by the
+        base name plus the increasing index.
+
+        Parameters
+        ----------
+        index_0: int
+            The index to start from when setting the macros to the cells'
+            regions.
+        base_name : str
+            The base name of the macros which defaults to 'MAC'.
+        """
+        box_layer = []
+        if self.lattice_box:
+            box_layer = [self.lattice_box]
+        # Loop through the lattice's cells first and then the box cell, if any
+        for layer in self.layers + [box_layer]:
+            for cell in layer:
+                cell.update_properties(
+                    {PropertyType.MACRO: [
+                        f"{base_name}{index_0}"]*len(cell.tech_geom_props)
+                    }
+                )
+                index_0 += 1
 
 
 def get_compound_from_geometry(

--- a/glow/geometry_layouts/lattices.py
+++ b/glow/geometry_layouts/lattices.py
@@ -2581,7 +2581,7 @@ class Lattice():
             for cell in layer:
                 cell.update_properties(
                     {PropertyType.MACRO: [
-                        f"{base_name}{index_0}"]*len(cell.tech_geom_props)
+                        f"{base_name}{index_0:03d}"]*len(cell.tech_geom_props)
                     }
                 )
                 index_0 += 1

--- a/glow/geometry_layouts/lattices.py
+++ b/glow/geometry_layouts/lattices.py
@@ -2200,13 +2200,6 @@ class Lattice():
         if self.symmetry_type != SymmetryType.FULL:
             self.lattice_symm = make_rotation(
                 self.lattice_symm, axis, rotation)
-        # Update the rotation angle of the main pattern of cells
-        try:
-            self.__cells_rot = self.__evaluate_cells_rotation(
-                self.lattice_cells)
-        except RuntimeError as e:
-            raise RuntimeError(
-                f"Error while rotating the lattice by {angle}°.") from e
         # Set the need to update the lattice geometry
         self.is_update_needed = True
         # Show the new lattice compound in the current SALOME study

--- a/glow/geometry_layouts/lattices.py
+++ b/glow/geometry_layouts/lattices.py
@@ -2579,6 +2579,9 @@ class Lattice():
                 )
                 index_0 += 1
 
+        # Set the need to update the lattice geometry
+        self.is_update_needed = True
+
 
 def get_compound_from_geometry(
         geo_type: GeometryType, lattice_cells: List[Cell]) -> Any:

--- a/glow/main.py
+++ b/glow/main.py
@@ -28,8 +28,8 @@ class TdtSetup:
     """
     geom_type: GeometryType = GeometryType.TECHNOLOGICAL
     """Identifying the type of geometry of the lattice's cells."""
-    property_type: PropertyType = PropertyType.MATERIAL
-    """Identifying the type of property associated to lattice's regions."""
+    property_types: PropertyType | List[PropertyType] = PropertyType.MATERIAL
+    """Identifying the type(s) of property associated to lattice's regions."""
     albedo: float | None = None
     """Identifying the value for the albedo applied to the lattice's BCs."""
     type_geo: LatticeGeometryType = LatticeGeometryType.ISOTROPIC
@@ -57,6 +57,9 @@ class TdtSetup:
                 raise RuntimeError(
                     f"The value {self.albedo} for the albedo is out of "
                     "bounds [0.0, 1.0]")
+        # Transform the given property type to a list
+        if not isinstance(self.property_types, List):
+            self.property_types = [self.property_types]
 
 
 def analyse_and_generate_tdt(

--- a/glow/support/types.py
+++ b/glow/support/types.py
@@ -117,6 +117,8 @@ class PropertyType(Enum):
     """
     MATERIAL: int = 0
     """Identifying the material property type."""
+    MACRO: int = 1
+    """Identifying the macro region a region belongs to."""
 
 
 # Dictionary associating for each type of cells, the valid combinations of

--- a/glow/support/utility.py
+++ b/glow/support/utility.py
@@ -5,18 +5,17 @@ of the geometry layouts.
 import math
 import random
 
-from types import CellType
 from typing import Any, List, Tuple
 
-from glow.interface.geom_interface import ShapeType, add_to_study, \
+from glow.interface.geom_interface import ShapeType, \
     extract_sorted_sub_shapes, extract_sub_shapes, fuse_edges_in_wire, \
-    get_angle_between_shapes, get_basic_properties, get_closed_free_boundary, get_kind_of_shape, \
-    get_min_distance, get_point_coordinates, get_selected_object, \
-    get_shape_name, get_shape_type, is_gui_available, make_cdg, make_compound, \
-    make_cut, make_edge, make_face, make_fuse, make_partition, \
-    make_translation, make_vector_from_points, make_vertex
-from glow.support.types import CELL_VS_SYMM_VS_TYP_GEO, LatticeGeometryType, \
-    SymmetryType
+    get_angle_between_shapes, get_basic_properties, get_closed_free_boundary, \
+    get_kind_of_shape, get_min_distance, get_point_coordinates, \
+    get_selected_object, get_shape_name, get_shape_type, \
+    is_gui_available, make_cdg, make_cut, make_edge, make_face, make_fuse, \
+    make_partition, make_translation, make_vector_from_points, make_vertex
+from glow.support.types import CELL_VS_SYMM_VS_TYP_GEO, CellType, \
+    LatticeGeometryType, SymmetryType
 
 
 # List of the RGB color codes taken by varying each RGB value with steps of 10
@@ -94,7 +93,7 @@ def build_compound_borders(cmpd: Any) -> List[Any]:
     """
     # Extract a list of closed boundaries from the given compound object
     closed_boundaries = get_closed_free_boundary(
-        make_partition([cmpd], [], ShapeType.COMPOUND))
+        make_partition([cmpd], [], ShapeType.FACE))
     # Handle the case where more than a closed wire is extracted from
     # the compound
     if len(closed_boundaries) > 1:

--- a/tests/unittest/test_geom_extractor.py
+++ b/tests/unittest/test_geom_extractor.py
@@ -559,7 +559,7 @@ class TestFace(unittest.TestCase):
         self.assertTrue(
             are_same_shapes(face.face, rect_face.face, ShapeType.FACE)
         )
-        self.assertEqual(face.property, prop_val)
+        self.assertEqual(face.properties, prop_val)
         self.assertEqual(face.no, 1)
         self.assertEqual(face.sort_index, 1)
         self.assertTrue(


### PR DESCRIPTION
To support the _multicell surfacic_ approach of DRAGON5, users needed the possibility to group regions of the layout in _macro_ regions, which exhibit similar characteristics from a neutronic perspective.

This requirement has been met by relying on the already present `PropertyType` enumeration with the addition of the `MACRO` element. Values for the `PropertyType.MACRO` property can be assigned to the regions of the layout by using the same methods of the `Cell` and `Lattice` classes used for setting the `MATERIAL` property type. 
When exporting the layout to the TDT file, users can now specify the list of `PropertyType` items to include. This list defaults to the `PropertyType.MATERIAL` value. The analysis step now is performed by taking into account all the indicated properties. If the `PropertyType.MACRO` is included, the names of the macro geometries and the indices assigned to the regions of the layout are written in the TDT file; otherwise the default values are used.

The `Cell` class has been updated by adding the new method `update_properties` to enable users to update a subset of the property types assigned to the cell's regions without restoring the internal dictionary in the process.

The `Lattice` class has been modified by adding the new method `assign_macro_to_cells` for assigning the same macro name to all the regions of a cell in the lattice; the method sets a different name for the macro associated to each cell by using an increasing index.

This pull request closes issue #53.