### PR TITLE
Solved TDT generation issue

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -698,7 +698,10 @@ objects in the hierarchy.
 The method :py:meth:`get_regions_with_symmetry()<glow.geometry_layouts.fillable_layouts.Fillable.get_regions_with_symmetry>`
 similarly retrieves the *regions* of the technological geometry, with the
 difference that only those in common with the shape of the indicated symmetry
-type are returned.
+type are returned. The underlying *common* operation can introduce numerical
+floating-point precision errors. To limit the effect, this method includes a
+boolean flag to specify whether the tolerances of the geometric elements of the
+``Regions`` objects should be limited to the `1e-6` value.
 
 Printing regions information
 """"""""""""""""""""""""""""

--- a/glow/generator/export_data.py
+++ b/glow/generator/export_data.py
@@ -514,7 +514,10 @@ class BoundaryData:
         # The border origin must be defined so that the angle between
         # the start-end points is positive. If not, the edge start point
         # is inverted.
-        if self.angle < -EPSILON or math.isclose(self.angle, 180.0):
+        if (
+            self.angle < -EPSILON
+            or math.isclose(self.angle, 180.0, abs_tol=EPSILON)
+        ):
             self.angle = get_angle_between_points(
                 (x2, y2, 0.0), (x1, y1, 0.0), True
             )
@@ -523,7 +526,7 @@ class BoundaryData:
         # If the angle is close to zero, it can happen that it is written
         # with a minus sign which is unnecessary; hence, it is set to 0.0
         # explicitly
-        if math.isclose(self.angle, 0.0, abs_tol=1e-6):
+        if math.isclose(abs(self.angle), 0.0, abs_tol=EPSILON):
             self.angle = 0.0
 
         # Initialize the border axes to the edge start point

--- a/glow/generator/geom_extractor.py
+++ b/glow/generator/geom_extractor.py
@@ -512,9 +512,11 @@ class LayoutDataExtractor():
             layout_cmpd = compound_to_analyse
         else:
             # Get the regions of the technological geometry of the layout
-            # according to indicated symmetry type
+            # according to indicated symmetry type, limiting the tolerances
+            # of the regions to avoid issues on the result of the common
+            # operations with the shape of the symmetry
             self.regions = self.geometry_layout.get_regions_with_symmetry(
-                tdt_setup.symmetry_type
+                tdt_setup.symmetry_type, True
             )
             # Get the GEOM compound identifying either the full layout of a
             # part of it

--- a/glow/geometry_layouts/fillable_layouts.py
+++ b/glow/geometry_layouts/fillable_layouts.py
@@ -19,11 +19,12 @@ from glow.interface.geom_entities import Compound, Edge, Face, Vertex, \
 from glow.interface.geom_interface import ShapeType, add_to_study, \
     add_to_study_in_father, clear_view, display_shape, extract_sub_shapes, \
     get_closed_free_boundary, get_min_distance, get_object_from_id, \
-    get_point_coordinates, get_shape_name, get_shape_type, \
-    is_point_inside_shape, make_cdg, make_common, make_compound, make_cut, \
-    make_face, make_partition, make_rotation, make_scale, make_translation, \
-    make_vector_from_points, make_vertex, make_vertex_inside_face, \
-    remove_from_study, set_color_face, update_salome_study
+    get_point_coordinates, get_shape_name, get_shape_type, get_tolerances, \
+    is_point_inside_shape, limit_tolerance, make_cdg, make_common, \
+    make_compound, make_cut, make_face, make_partition, make_rotation, \
+    make_scale, make_translation, make_vector_from_points, make_vertex, \
+    make_vertex_inside_face, remove_from_study, set_color_face, \
+    update_salome_study
 from glow.support.types import GeometryType, PropertyType, SymmetryType
 from glow.support.utility import are_same_shapes, build_z_axis_from_vertex, \
     compute_point_by_reference, flatten_list, retrieve_selected_object
@@ -307,7 +308,7 @@ class Fillable(Compound, Layout):
         ]
 
     def get_regions_with_symmetry(
-            self, symmetry: SymmetryType
+            self, symmetry: SymmetryType, apply_tolerance_limit: bool = False
         ) -> List[Region]:
         """
         Method that collects and returns all the ``Region`` objects from the
@@ -318,12 +319,18 @@ class Fillable(Compound, Layout):
         the symmetry type are returned.
         If no shape is stored for the indicated symmetry type, an exception
         is raised.
+        If indicated, the tolerances of the geometric elements of the
+        ``Regions`` objects are limited to the 1e-6 value to avoid geometric
+        inconsistencies on the result of the common operation.
 
         Parameters
         ----------
         symmetry : SymmetryType
             The type of symmetry for which the corresponding ``Region``
             objects of the layout are returned.
+        apply_tolerance_limit : bool
+            If ``True``, the tolerances of the geometric elements of the
+            ``Regions`` objects are limited to the 1e-6 value.
 
         Returns
         ----------
@@ -352,6 +359,14 @@ class Fillable(Compound, Layout):
                 "desired symmetry type."
             )
         symm_shape = self.symmetry_map[symmetry]
+
+        # Limit the tolerance of the GEOM elements of the region to avoid
+        # geometric inconsistencies when applying the common operation
+        if apply_tolerance_limit:
+            for region in regions:
+                if max(get_tolerances(region)) < 1e-6:
+                    region.geom_obj = limit_tolerance(region)
+
         # Return the regions in common with the shape of the symmetry
         common_regions = []
         for region in regions:

--- a/glow/interface/geom_interface.py
+++ b/glow/interface/geom_interface.py
@@ -399,7 +399,7 @@ def get_kind_of_shape(shape: Any) -> List[Any]:
 
     Notes
     -----
-    Values lesser than the tolerance of 1e-10 are substituted with ``0`` in
+    Values lesser than the tolerance of 1e-6 are substituted with ``0`` in
     the returned list.
 
     Parameters
@@ -415,10 +415,10 @@ def get_kind_of_shape(shape: Any) -> List[Any]:
     # Extract the list of information about the given shape
     kind_of_shape = geompy.KindOfShape(shape)
     # Loop over all the retrieved values and substitute with '0' values
-    # lesser than the 1e-15 tolerance
+    # lesser than the 1e-6 tolerance
     for i, info in enumerate(kind_of_shape):
         if isinstance(info, float):
-            if abs(info) < 1e-10:
+            if abs(info) < 1e-6:
                 kind_of_shape[i] = 0
     return kind_of_shape
 
@@ -557,6 +557,28 @@ def get_subshape_id(shape: Any, subshape: Any) -> str:
     return geompy.GetSubShapeID(shape, subshape)
 
 
+def get_tolerances(shape: Any) -> List[float]:
+    """
+    Function that returns the min-max tolerances applied to the GEOM objects
+    the shape is constituted by.
+    In order, they are those for the faces, the edges, and the vertices of
+    the shape. If the shape is not composed of any of these sub-shapes, an
+    infinite number is returned instead.
+
+    Parameters
+    ----------
+    shape : Any
+        The GEOM object whose tolerances are returned.
+
+    Returns
+    -------
+    List[float]
+        In order, the min-max tolerances of the faces, the edges, the vertices
+        the shape is made of.
+    """
+    return geompy.Tolerance(shape)
+
+
 def is_point_inside_shape(point: Any, shape: Any) -> bool:
     """
     Function that checks if the given point object is within the boundaries
@@ -589,6 +611,27 @@ def is_gui_available() -> None:
         ``True`` if the SALOME GUI is available, ``False`` otherwise.
     """
     return salome.sg.hasDesktop()
+
+
+def limit_tolerance(shape: Any, max_tol: float = 1e-6) -> Any:
+    """
+    Function that tries to limit the tolerances applied to the GEOM objects
+    the given shape is made of.
+
+    Parameters
+    ----------
+    shape : Any
+        The shape to process.
+    max_tol : float = 1e-6
+        The maximum required tolerance the shape should be limited to.
+
+    Returns
+    -------
+    Any
+        A new GEOM object from the given shape with tolerances limited to the
+        required value.
+    """
+    return geompy.LimitTolerance(shape, max_tol)
 
 
 def make_arc(point1: Any, point2: Any, point3: Any) -> Any:

--- a/tests/unittest/test_geom_extractor.py
+++ b/tests/unittest/test_geom_extractor.py
@@ -18,15 +18,16 @@ from glow.geometry_layouts.geometries import Circle, Hexagon, Rectangle
 from glow.geometry_layouts.lattices import CartesianLattice, HexLattice, Lattice
 from glow.geometry_layouts.layouts import Region
 from glow.interface.geom_entities import Face, Vertex, wrap_shape
-from glow.interface.geom_interface import ShapeType, extract_sub_shapes, get_basic_properties, \
-    get_shape_name, make_arc_center, make_cdg, make_circle, make_common, make_compound, \
+from glow.interface.geom_interface import ShapeType, extract_sub_shapes, \
+    get_shape_name, limit_tolerance, make_circle, make_common, make_compound, \
     make_edge, make_face, make_partition, make_translation, make_vector, \
     make_vertex, set_shape_name
 from glow.main import TdtSetup
 from glow.support.types import GeometryType, LayoutGeometryType, LayoutType, \
     PropertyType, SymmetryType
-from glow.support.utility import are_same_shapes, build_contiguous_edges
-from tests.unittest.support_funcs import build_colorset, capture_output
+from glow.support.utility import are_same_shapes, build_compound_borders, \
+    build_contiguous_edges
+from tests.unittest.support_funcs import build_colorset
 
 
 class TestLayoutDataExtractor(unittest.TestCase):
@@ -562,7 +563,7 @@ class TestLayoutDataExtractor(unittest.TestCase):
         self.assertIn("0", output[3])
         self.assertIn("0", output[4])
 
-    def test_preprocess_cart_lattice(self) -> None:
+    def test_preprocess_cart_assembly(self) -> None:
         """
         Method that tests the implementation of the method `_preprocess` of
         the `LayoutDataExtractor` class.
@@ -695,7 +696,7 @@ class TestLayoutDataExtractor(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             lde._preprocess(tdt_setup, layout)
 
-    def test_preprocess_hex_lattice(self) -> None:
+    def test_preprocess_hex_assembly(self) -> None:
         """
         Method that tests the implementation of the method `_preprocess` of
         the `LayoutDataExtractor` class.
@@ -772,6 +773,77 @@ class TestLayoutDataExtractor(unittest.TestCase):
         )
         self.__assess_preprocess_hex_symm(assembly, lde, sec_geo)
 
+    def test_preprocess_hex_assembly_numerical_precision(self) -> None:
+        """
+        Method that tests the implementation of the method `_preprocess` of
+        the `LayoutDataExtractor` class.
+
+        An assembly made by a hexagonal lattice is used for testing purposes.
+        This test checks the `_preprocess` method against a specific layout
+        that caused issues in determining the correct borders and edges.
+        The problem was related to the tolerances applied to the sub-shapes
+        which resulted in the presence of edges with length equal to the
+        tolerance.
+
+        This test builds the same layout and checks that the implementation
+        processes the layout correctly for a one sixth and a third of the
+        full layout.
+        """
+        # Build the hexagonal assembly
+        cell = HexCell(side=0.7852193995)
+        cell.rotate(90)
+        cell.sectorize([6], [0])
+        lattice = HexLattice([cell])
+        lattice.add_rings_of_cells(cell, 6)
+        assembly = HexCell(side=lattice.dimensions[0] + 2*0.05*cos(pi/3))
+        assembly.add(
+            Region(
+                Hexagon(edge_length=lattice.dimensions[0] + 0.05*cos(pi/3))
+                - lattice.shape,
+                properties={PropertyType.MATERIAL: "CLADDING"}
+            )
+        )
+        assembly.add(lattice)
+        assembly.update_hierarchical_structure()
+
+        # Set the number of regions and the shape of the simmetries used for
+        # comparison purposes (no regions for the sectorised type)
+        self.hex_symm_vs_regions = {
+            SymmetryType.THIRD: {
+                GeometryType.TECHNOLOGICAL: 66, GeometryType.SECTORIZED: None
+            },
+            SymmetryType.SIXTH: {
+                GeometryType.TECHNOLOGICAL: 38, GeometryType.SECTORIZED: None
+            }
+        }
+        box_lx = lattice.dimensions[0] + 2*0.05*cos(pi/3)
+        box_ly = box_lx * sin(pi/3)
+        self.hex_symm_vs_shape: Dict[SymmetryType, Any] = {
+            SymmetryType.THIRD: make_face(build_contiguous_edges([
+                make_vertex((0.0, 0.0, 0.0)),
+                make_vertex((box_lx, 0.0, 0.0)),
+                make_vertex((3/2*box_lx, box_ly, 0.0)),
+                make_vertex((1/2*box_lx, box_ly, 0.0)),
+            ])),
+            SymmetryType.SIXTH: make_face(build_contiguous_edges([
+                make_vertex((0.0, 0.0, 0.0)),
+                make_vertex((box_lx, 0.0, 0.0)),
+                make_vertex((box_lx/2, box_ly, 0.0))
+            ]))
+        }
+
+        # Instantiate the 'LayoutDataExtractor' class without attributes
+        lde = LayoutDataExtractor.__new__(LayoutDataExtractor)
+        # Verify the preprocess activities are performed correctly with a
+        # sixth symmetry that must be translated so that its lower-left
+        # corner is in the XYZ origin
+        assembly.apply_symmetry(SymmetryType.SIXTH)
+        self.__assess_preprocess_hex_symm(assembly, lde)
+        # Verify the preprocess activities are performed correctly with a
+        # third symmetry (a translation is needed)
+        assembly.apply_symmetry(SymmetryType.THIRD)
+        self.__assess_preprocess_hex_symm(assembly, lde)
+
     def __assess_preprocess_colorset(
             self,
             portion: Any | None,
@@ -847,7 +919,9 @@ class TestLayoutDataExtractor(unittest.TestCase):
         cmpd = (
             assembly
             if symm_type == SymmetryType.FULL
-            else assembly * assembly.symmetry_map[symm_type]
+            else wrap_shape(
+                limit_tolerance(assembly)
+            ) * assembly.symmetry_map[symm_type]
         )
         # Get the compound + the refinment edges, if needed
         if geom_type == GeometryType.SECTORIZED:
@@ -935,6 +1009,9 @@ class TestLayoutDataExtractor(unittest.TestCase):
             with those stored during the preprocess activities.
         """
         self.assertEqual(len(lde.regions), no_regions)
+        self.assertEqual(
+            len(lde.borders), len(build_compound_borders(cmpr_shape))
+        )
         self.assertTrue(
             are_same_shapes(
                 make_face(lde.borders),
@@ -942,11 +1019,6 @@ class TestLayoutDataExtractor(unittest.TestCase):
                 ShapeType.FACE
             )
         )
-        p = make_partition(
-                    extract_sub_shapes(cmpd, ShapeType.EDGE),
-                    [],
-                    ShapeType.EDGE
-                )
         self.assertTrue(
             are_same_shapes(
                 make_compound(lde.layout_edges),


### PR DESCRIPTION
The hexagonal assembly used in the functional tests presented numerical precision and geometric tolerance issues affecting the TDT representation of its SIXTH and THIRD symmetries.
The following introduced changes ensure that both symmetries can be exported and tracked correctly by the _SALT:_ module of DRAGON5.

1. Improved zero-value detection found for SIXTH symmetry. Increased the tolerance threshold in the `get_kind_of_shape` function below which floating-point values are considered zero. This change resolves numerical precision issues where vertices had coordinates close to zero (1e-7), but were incorrectly treated as non-zero.

2. Geometry tolerance handling. For a THIRD symmetry of the hexagonal layout, an extra border edge was being introduced during the collection of the geometric data to be written in the TDT file. In particular, this happened due to model tolerances when the `Region` objects in common with the symmetry shape were determined by applying the boolean *common* operation (method `get_regions_with_symmetry`). To overcome the issue, the tolerances of the geometric objects of the regions are limited to 1e-6 before performing the common operation.

3. New tolerance control flag in the `get_regions_with_symmetry` method. A new boolean flag was added to the parameters of this method to control whether region tolerances should be limited. Depending on the context, the following behaviour is adopted: when called for determining the regions to show, the flag is left to its default False value; when called during the TDT export procedure, the flag is set to True to tackle possible issues.

4. Boundary angle detection. For a THIRD symmetry of the hexagonal layout, an angle of 180° was assigned to the X-oriented internal border when its information was exported in the TDT file. Now, a proper tolerance is set to detect 180° angles, converting them to 0°. 

5. The new functions `get_tolerances` and `limit_tolerance` have been introduced in the `geom_interface.py` module to support the adopted changes.

6. Unit test updates. A new unit test has been added to verify that the specific hexagonal layout highlighting the tackled issue is processed correctly for both a SIXTH and THIRD symmetry type.

7. The documentation has been updated to describe the presence of the new flag for the method `get_regions_with_symmetry`.