### PR TITLE
Handled degenerate edges during export

### DIFF
--- a/glow/generator/geom_extractor.py
+++ b/glow/generator/geom_extractor.py
@@ -22,7 +22,7 @@ from glow.interface.geom_interface import ShapeType, add_to_study, \
 from glow.main import TdtSetup
 from glow.support.types import GeometryType, LayoutGeometryType, LayoutType, \
     PropertyType, SymmetryType
-from glow.support.utility import are_same_shapes, build_compound_borders, get_edge_tolerance, \
+from glow.support.utility import are_same_shapes, build_compound_borders, \
     translate_wrt_reference
 
 

--- a/glow/generator/geom_extractor.py
+++ b/glow/generator/geom_extractor.py
@@ -15,14 +15,14 @@ from glow.geometry_layouts.fillable_layouts import Fillable
 from glow.geometry_layouts.layouts import build_compound_regions
 from glow.interface.geom_entities import Compound, wrap_shape
 from glow.interface.geom_interface import ShapeType, add_to_study, \
-    extract_sub_shapes, get_bounding_box, get_in_place, \
+    extract_sub_shapes, get_basic_properties, get_bounding_box, get_in_place, \
     get_in_place_by_hystory, get_point_coordinates, get_shape_name, \
     get_shape_type, make_compound, make_face, make_partition, \
     make_partition_non_self_intersecting, make_vertex, update_salome_study
 from glow.main import TdtSetup
 from glow.support.types import GeometryType, LayoutGeometryType, LayoutType, \
     PropertyType, SymmetryType
-from glow.support.utility import are_same_shapes, build_compound_borders, \
+from glow.support.utility import are_same_shapes, build_compound_borders, get_edge_tolerance, \
     translate_wrt_reference
 
 
@@ -202,6 +202,7 @@ class LayoutDataExtractor():
         # Initialize the dictionary storing the edges names VS the list of
         # connected faces
         edges_name_vs_faces : Dict[str, List[Any | FaceData]] = {}
+        layout_edges_cmpd = make_compound(self.layout_edges)
         # Loop through all the layout subfaces ('FaceData' objects)
         print("LEN SUBFACES", len(self.subfaces))
         for subface in self.subfaces:
@@ -210,10 +211,13 @@ class LayoutDataExtractor():
             # Loop through all the edges of the current subface
             for subface_edge, edge_id in subface.edge_vs_id.items():
                 # Extract the corresponding GEOM edge object(s)
-                unique_edges = self._get_unique_edges(subface_edge, edge_id)
+                unique_edges = self._get_unique_edges(
+                    subface_edge, edge_id, layout_edges_cmpd
+                )
                 # Update the dictionary of edge names VS connected faces
                 self._update_edge_face_association(
-                    edges_name_vs_faces, subface, unique_edges)
+                    edges_name_vs_faces, subface, unique_edges
+                )
         # Return the dictionary of edge names VS the list of connected faces
         return edges_name_vs_faces
 
@@ -445,6 +449,10 @@ class LayoutDataExtractor():
                 [refined_cmpd],
                 ShapeType.FACE
             )
+        logging.info(
+            "Created the partition between the regions and the compound of "
+            + "edges of the SECTORIZED geometry."
+        )
         # For each region, recover its image in the partition, i.e. the faces
         # in which it has been partitioned
         refined_regions = []
@@ -565,7 +573,7 @@ class LayoutDataExtractor():
         return self.geometry_layout.geometry_maps[tdt_setup.geom_type]
 
     def _get_unique_edges(
-            self, subface_edge: Any, edge_id: str
+            self, subface_edge: Any, edge_id: str, layout_edges_cmpd: Any
         ) -> List[Any]:
         """
         Method that retrieves the GEOM edge objects associated to the given
@@ -592,6 +600,9 @@ class LayoutDataExtractor():
             The GEOM edge object to retrieve the corresponding sub-edges from.
         edge_id : str
             The ID of the edge to look for in the dictionary of IDs VS edges.
+        layout_edges_cmpd : Any
+            The GEOM compound of edges where the given edge has to be looked
+            for.
 
         Raises
         ------
@@ -603,22 +614,31 @@ class LayoutDataExtractor():
         List[Any]
             A list of GEOM edge objects that is either directly associated to
             the given ID, or representing the sub-edges the edge can be
-            subdivided into.
+            subdivided into. It can be empty in case of a degenerate edge.
         """
         try:
             return [self.id_vs_edge[edge_id]]
         except KeyError as exc:
             # Get the sub-edges the given edge can be subdivided into: these
             # are associated to a different face of the layout
-            edge = get_in_place(make_compound(self.layout_edges),
-                                subface_edge)
+            edge = get_in_place(layout_edges_cmpd, subface_edge)
+            error_message = "No corresponding edge in the layout could " +\
+                f"be retrieved for the subface edge whose data is {edge_id}."
+            # Handle the case no results from "get_in_place" are given
+            if not edge:
+                degen_tol = 1e-5
+                if get_basic_properties(subface_edge)[0] <= degen_tol:
+                    logging.warning(
+                        f"{error_message} In addition, the edge length is "
+                        f"below the degeneracy tolerance of {degen_tol}. For "
+                        "this reason, the edge will be ignored."
+                    )
+                    return []
+                raise RuntimeError(error_message) from exc
             # Only edge and compound of edges are treated
             edge_type = get_shape_type(edge)
-            error_message = "No corresponding edge in the layout could " +\
-                f"be retrieved for the subface edge whose data is {edge_id}"
-            if not edge or edge_type not in [ShapeType.COMPOUND,
-                                             ShapeType.EDGE]:
-                raise RuntimeError(error_message) from exc
+            if edge_type not in [ShapeType.COMPOUND, ShapeType.EDGE]:
+                raise RuntimeError(error_message + f"{edge_type}") from exc
             # EDGE-type case
             if not edge_type == ShapeType.COMPOUND:
                 return [self.id_vs_edge[build_edge_id(edge)]]

--- a/glow/geometry_layouts/cells.py
+++ b/glow/geometry_layouts/cells.py
@@ -13,7 +13,7 @@ from glow.geometry_layouts.layouts import Region
 from glow.geometry_layouts.symmetry_management import SymmetryDomain, \
     build_cartesian_symmetry_shape, build_hex_symmetry_shape, \
     use_symmetry_logic
-from glow.interface.geom_entities import Edge, wrap_shape
+from glow.interface.geom_entities import Compound, Edge, wrap_shape
 from glow.interface.geom_interface import get_bounding_box, get_min_distance, \
     get_point_coordinates, make_cdg, make_compound, make_edge, \
     make_intersection, make_rotation
@@ -380,7 +380,9 @@ class Cell(Fillable):
         #   the 'windmill' option is active)
         edges = self._build_sectorization_edges(sectors_no, angles, windmill)
         # Store the GEOM compound of the edges in the mapping
-        self.geometry_maps[GeometryType.SECTORIZED] = make_compound(edges)
+        self.geometry_maps[GeometryType.SECTORIZED] = Compound(
+            make_compound(edges)
+        )
 
     def _translate_layout_specific_elems(
             self, new_cntr: Tuple[float, float, float]

--- a/glow/support/utility.py
+++ b/glow/support/utility.py
@@ -719,6 +719,36 @@ def is_vertex_on_edge(vertex: Any, edge: Any) -> bool:
         ``True`` in case the vertex is on the edge (within the calculated
         tolerance), ``False`` otherwise.
     """
+    # Get the GEOM tolerances for the vertex
+    vrtx_tol = max(get_tolerances(vertex)[-2:-1])
+    # Calculate the final tolerance as the maximum value between the tolerance
+    # of the edge and the vertex
+    combined_tol = max(get_edge_tolerance(edge), vrtx_tol)
+
+    # Calculate the vertex-edge distance and return if this is within the
+    # tolerance
+    return math.isclose(
+        abs(get_min_distance(vertex, edge)) - combined_tol,
+        0.0,
+        abs_tol=combined_tol
+    )
+
+def get_edge_tolerance(edge: Any) -> float:
+    """
+    Calculate the tolerance the given edge based on its bounding box, length,
+    and tolerances assigned to the edge itself and the vertex objects it is
+    made of.
+
+    Parameters
+    ----------
+    edge : Any
+        The edge object to calculate tolerance for.
+
+    Returns
+    -------
+    float
+        The calculated edge tolerance.
+    """
     # Declare scaling factors and the min/max tolerances to consider
     edge_bbox_factor = 1e-7
     edge_len_factor = 1e-6
@@ -733,24 +763,10 @@ def is_vertex_on_edge(vertex: Any, edge: Any) -> bool:
     # Get the GEOM tolerances for the edge and its vertices only
     _, *tols = get_tolerances(edge)
     geom_edge_tol = max(tols)
-    # Get the GEOM tolerances for the vertex
-    vrtx_tol = max(get_tolerances(vertex)[-2:-1])
-
     # Calculate the edge tolerance by combining all the three values and
     # comparing wrt the minimum and maximum allowed values
     edge_total_tol = max(bbox_tol, length_tol, geom_edge_tol)
-    edge_total_tol = min(max(edge_total_tol, min_tol), max_tol)
-    # Calculate the final tolerance as the maximum value between the tolerance
-    # of the edge and the vertex
-    combined_tol = max(edge_total_tol, vrtx_tol)
-
-    # Calculate the vertex-edge distance and return if this is within the
-    # tolerance
-    return math.isclose(
-        abs(get_min_distance(vertex, edge)) - combined_tol,
-        0.0,
-        abs_tol=combined_tol
-    )
+    return min(max(edge_total_tol, min_tol), max_tol)
 
 
 def retrieve_selected_object(error_msg: str) -> Any:

--- a/tests/unittest/test_geom_extractor.py
+++ b/tests/unittest/test_geom_extractor.py
@@ -15,9 +15,10 @@ from glow.generator.export_data import EdgeData, FaceData, build_edge_id, \
 from glow.generator.geom_extractor import LayoutDataExtractor, analyse_layout
 from glow.geometry_layouts.cells import HexCell, CartesianCell
 from glow.geometry_layouts.geometries import Circle, Hexagon, Rectangle
-from glow.geometry_layouts.lattices import CartesianLattice, HexLattice, Lattice
+from glow.geometry_layouts.lattices import CartesianLattice, HexLattice, \
+    Lattice
 from glow.geometry_layouts.layouts import Region
-from glow.interface.geom_entities import Face, Vertex, wrap_shape
+from glow.interface.geom_entities import Face, wrap_shape
 from glow.interface.geom_interface import ShapeType, extract_sub_shapes, \
     get_shape_name, limit_tolerance, make_circle, make_common, make_compound, \
     make_edge, make_face, make_partition, make_translation, make_vector, \

--- a/tests/unittest/test_geom_extractor.py
+++ b/tests/unittest/test_geom_extractor.py
@@ -449,7 +449,7 @@ class TestLayoutDataExtractor(unittest.TestCase):
 
     def test_get_unique_edges(self) -> None:
         """
-        Method that tests the implementation of the `__get_unique_edges`
+        Method that tests the implementation of the `_get_unique_edges`
         method of the `LayoutDataExtractor` class.
 
         Notes
@@ -478,6 +478,7 @@ class TestLayoutDataExtractor(unittest.TestCase):
             ]
         ]
         id_vs_edge = classify_layout_edges(layout_edges)
+        layout_edges_cmpd = make_compound(layout_edges)
 
         # Instantiate the 'LayoutDataExtractor' class without attributes
         # and only initialise the needed attributes
@@ -489,7 +490,9 @@ class TestLayoutDataExtractor(unittest.TestCase):
         # ones
         edge_to_test = list(id_vs_edge.values())[0]
         edge_id = list(id_vs_edge.keys())[0]
-        found_edges = lde._get_unique_edges(edge_to_test, edge_id)
+        found_edges = lde._get_unique_edges(
+            edge_to_test, edge_id, layout_edges_cmpd
+        )
         # Verify only one edge is returned and that is present among the
         # stored ones
         self.assertEqual(len(found_edges), 1)
@@ -503,7 +506,9 @@ class TestLayoutDataExtractor(unittest.TestCase):
             make_vertex((1.0, 1.0, 0.0)), make_vertex((1.0, 0.0, 0.0))
         )
         edge_id = build_edge_id(edge_to_test)
-        found_edges = lde._get_unique_edges(edge_to_test, edge_id)
+        found_edges = lde._get_unique_edges(
+            edge_to_test, edge_id, layout_edges_cmpd
+        )
         # Verify two edges are returned and that are the ones belonging to
         # the first cell
         self.assertEqual(len(found_edges), 2)
@@ -519,8 +524,79 @@ class TestLayoutDataExtractor(unittest.TestCase):
         invalid_edge = make_circle(make_vertex((0.0, 0.0, 0.0)), None, 1.0)
         with self.assertRaises(RuntimeError):
             _ = lde._get_unique_edges(
-                invalid_edge, build_edge_id(invalid_edge)
+                invalid_edge, build_edge_id(invalid_edge), layout_edges_cmpd
             )
+
+    def test_get_unique_edges_degenerate(self) -> None:
+        """
+        Method that tests that the `_get_unique_edges` method returns an empty
+        list when an edge cannot be retrieved from the layout and its length
+        is below the degeneracy tolerance.
+        The test reproduces a hexagonal assembly geometry known to generate
+        degenerate edges when the whole geometry layout is assembled and
+        confirms that such edges are skipped rather than treated as an error.
+        """
+        edge_length = 0.78521393995
+        cell = HexCell(side=edge_length)
+        cell.rotate(90)
+        lattice = HexLattice([cell], name="Fuel lattice")
+        lattice.add_rings_of_cells(cell, 6)
+        # Enclose the lattice in a hexagonal cell being its box
+        layer_thickness = 0.05
+        assembly = HexCell(
+            side=lattice.dimensions[0] + 2*layer_thickness*cos(pi/3),
+        )
+        assembly.add(
+            Region(
+                Hexagon(
+                    edge_length=(
+                        lattice.dimensions[0] + layer_thickness*cos(pi/3)
+                    )
+                ) - lattice.shape
+            )
+        )
+        assembly.add(lattice)
+        # Apply the 'SIXTH' symmetry type
+        assembly.apply_symmetry(SymmetryType.SIXTH)
+        # Extract the unique edges from the partition of the regions
+        layout_edges = extract_sub_shapes(
+            make_partition(
+                assembly.get_regions_with_symmetry(SymmetryType.SIXTH),
+                [],
+                ShapeType.EDGE
+            ),
+            ShapeType.EDGE
+        )
+        id_vs_edge = classify_layout_edges(layout_edges)
+        # Translate the edges so that the layout's origin coincides with the
+        # one considered during the analysis
+        layout_edges_cmpd = make_translation(
+            make_compound(layout_edges),
+            make_vector((4.55846632, 7.89549527, 0.0))
+        )
+
+        # Instantiate the 'LayoutDataExtractor' class without attributes
+        # and only initialise the needed attributes
+        lde = LayoutDataExtractor.__new__(LayoutDataExtractor)
+        lde.layout_edges = layout_edges
+        lde.id_vs_edge = id_vs_edge
+
+        # Verify the returned list of edges is empty in case the provided
+        # edge is not found among the edges of the whole compound, but it
+        # is degenerate, i.e. its length is lower the 1e-5 tolerance. This
+        # case is not treated as an error, but it is simply skipped.
+        degenerate_edge = make_edge(
+            make_vertex((0.478343, 0.0433013, 0.0)),
+            make_vertex((0.478343, 0.0433009, 0.0))
+        )
+        self.assertListEqual(
+            lde._get_unique_edges(
+                degenerate_edge,
+                build_edge_id(degenerate_edge),
+                layout_edges_cmpd
+            ),
+            []
+        )
 
     def test_print_log_analysis(self) -> None:
         """


### PR DESCRIPTION
During the TDT export process of a geometry layout, it is possible that some regions can contain degenerate edges. This is because SALOME's GEOM introduces them to preserve a valid topological representation, e.g., to ensure a GEOM face is closed. In this situation, an exception was raised whenever such edges were not found in the compound of all the edges of the geometry, which is built after healing it (with a partition operation) from any duplicate edges. 

However, this behaviour was too restrictive, since the missing edge in the compound is not the result of an actual topological inconsistency. Therefore, the implementation of the `_get_unique_edges` method of the `LayoutDataExtractor` class has been updated to detect this condition. Now, when no matching edge is retrieved, the following steps are performed:

- The length of the region's edge is compared against a degeneracy tolerance.
- If the edge length falls below a tolerance level, the edge is considered degenerate.
- A warning is logged and the edge skipped by returning an empty list instead of raising an exception. 
- The existing error handling remains unchanged for all non-degenerate edges.

To ensure that degenerate edges are correctly excluded from the analysis, a new unit test has been included. This test is based on a hexagonal assembly which is known to produce degenerate edges when the geometry layout is assembled and the `SymmetryType.SIXTH` is applied to extract a one sixth portion. The test confirms that such edges are skipped rather than treated as an error.